### PR TITLE
Add per-page social metadata and blog structured data

### DIFF
--- a/src/hooks/usePageMetadata.js
+++ b/src/hooks/usePageMetadata.js
@@ -1,0 +1,112 @@
+import { useEffect } from 'react'
+
+const SITE_URL = 'https://www.gerardo-mena.com'
+const SITE_NAME = 'Gerardo Mena'
+const DEFAULT_IMAGE = '/social-media.png'
+
+const ensureAbsoluteUrl = (value) => {
+  if (!value) return undefined
+  if (/^https?:\/\//i.test(value)) return value
+  if (value.startsWith('//')) return `https:${value}`
+  const normalizedBase = SITE_URL.replace(/\/$/, '')
+  const normalizedPath = value.startsWith('/') ? value : `/${value}`
+  return `${normalizedBase}${normalizedPath}`
+}
+
+const setMetaTag = (attribute, key, content) => {
+  if (!key) return
+  let tag = document.head.querySelector(`meta[${attribute}="${key}"]`)
+  if (!tag) {
+    tag = document.createElement('meta')
+    tag.setAttribute(attribute, key)
+    document.head.appendChild(tag)
+  }
+  tag.setAttribute('content', content ?? '')
+}
+
+const removeMetaTag = (attribute, key) => {
+  const tag = document.head.querySelector(`meta[${attribute}="${key}"]`)
+  if (tag) {
+    document.head.removeChild(tag)
+  }
+}
+
+const setCanonicalLink = (href) => {
+  if (!href) return
+  let link = document.head.querySelector('link[rel="canonical"]')
+  if (!link) {
+    link = document.createElement('link')
+    link.setAttribute('rel', 'canonical')
+    document.head.appendChild(link)
+  }
+  link.setAttribute('href', href)
+}
+
+export default function usePageMetadata(options) {
+  const {
+    title,
+    description,
+    image,
+    url,
+    type = 'website',
+    publishedTime,
+    modifiedTime
+  } = options || {}
+
+  useEffect(() => {
+    if (!options) return
+
+    const pageTitle = title?.trim()
+    const pageDescription = description?.trim()
+    const absoluteImage = ensureAbsoluteUrl(image || DEFAULT_IMAGE)
+    const pageUrl = ensureAbsoluteUrl(
+      url || (typeof window !== 'undefined' ? window.location.pathname : '/')
+    )
+
+    if (pageTitle) {
+      document.title = pageTitle
+    }
+
+    if (pageUrl) {
+      setCanonicalLink(pageUrl)
+    }
+
+    setMetaTag('name', 'description', pageDescription || '')
+
+    setMetaTag('property', 'og:title', pageTitle || SITE_NAME)
+    setMetaTag('property', 'og:description', pageDescription || '')
+    if (absoluteImage) {
+      setMetaTag('property', 'og:image', absoluteImage)
+      setMetaTag('property', 'og:image:secure_url', absoluteImage)
+      setMetaTag('property', 'og:image:alt', pageTitle || SITE_NAME)
+    }
+    if (pageUrl) {
+      setMetaTag('property', 'og:url', pageUrl)
+    }
+    setMetaTag('property', 'og:type', type)
+    setMetaTag('property', 'og:site_name', SITE_NAME)
+
+    setMetaTag('name', 'twitter:card', 'summary_large_image')
+    setMetaTag('name', 'twitter:title', pageTitle || SITE_NAME)
+    setMetaTag('name', 'twitter:description', pageDescription || '')
+    if (absoluteImage) {
+      setMetaTag('name', 'twitter:image', absoluteImage)
+      setMetaTag('name', 'twitter:image:alt', pageTitle || SITE_NAME)
+    }
+    if (pageUrl) {
+      setMetaTag('name', 'twitter:url', pageUrl)
+    }
+
+    if (type === 'article') {
+      if (publishedTime) {
+        setMetaTag('property', 'article:published_time', publishedTime)
+      }
+      if (modifiedTime) {
+        setMetaTag('property', 'article:modified_time', modifiedTime)
+      }
+    } else {
+      removeMetaTag('property', 'article:published_time')
+      removeMetaTag('property', 'article:modified_time')
+    }
+  }, [title, description, image, url, type, publishedTime, modifiedTime])
+}

--- a/src/pages/About.jsx
+++ b/src/pages/About.jsx
@@ -1,4 +1,14 @@
+import usePageMetadata from '../hooks/usePageMetadata'
+
 function About() {
+  usePageMetadata({
+    title: 'About Gerardo Mena | Veteran Strategist & AI Innovator',
+    description:
+      'Discover the journey of Gerardo “Tony” Mena—from elite special operations to acclaimed author and AI strategist leading next-generation storytelling.',
+    image: '/Gerardo-Mena-Future.webp',
+    url: 'https://www.gerardo-mena.com/about'
+  })
+
   return (
     <>
       {/* Full-width Hero Image */}

--- a/src/pages/Blog.jsx
+++ b/src/pages/Blog.jsx
@@ -1,6 +1,16 @@
 import { Link } from 'react-router-dom'
 
+import usePageMetadata from '../hooks/usePageMetadata'
+
 function Blog() {
+  usePageMetadata({
+    title: 'Blog | Insights on AI Strategy & Creative Leadership',
+    description:
+      'Read the latest articles from Gerardo Mena on AI-driven marketing, creative leadership, and the future of generative search.',
+    image: '/GEO-Feature.png',
+    url: 'https://www.gerardo-mena.com/blog'
+  })
+
   return (
     <section className="py-20 px-8 pt-32">
       <div className="container mx-auto max-w-6xl">

--- a/src/pages/BlogPost.jsx
+++ b/src/pages/BlogPost.jsx
@@ -1,22 +1,56 @@
 import { useState, useEffect } from 'react'
 import { useParams, Link } from 'react-router-dom'
 
+import usePageMetadata from '../hooks/usePageMetadata'
+
 function BlogPost() {
   const { slug } = useParams()
   const [post, setPost] = useState(null)
   const [loading, setLoading] = useState(true)
 
+  const pageUrl = `https://www.gerardo-mena.com/blog/${slug}`
+
+  usePageMetadata(
+    post
+      ? {
+          title: `${post.title} | Gerardo Mena Blog`,
+          description: post.excerpt,
+          image: post.heroImage,
+          url: pageUrl,
+          type: 'article',
+          publishedTime: post.publishedTime,
+          modifiedTime: post.updatedTime || post.publishedTime
+        }
+      : null
+  )
+
   useEffect(() => {
-    // Load blog posts based on slug
+    setLoading(true)
+    setPost(null)
+
+    const removeStructuredData = () => {
+      const existing = document.getElementById('structured-data-article')
+      if (existing) {
+        existing.remove()
+      }
+    }
+
+    removeStructuredData()
+
+    let postData = null
+
     if (slug === 'what-a-week') {
-      const postData = {
-        title: "What a Week!",
-        author: "Gerardo Mena",
-        date: "2025-08-25",
-        excerpt: "We rushed a documentary onto a Vegas jumbotron, then briefed the Harding Project on AI—exhausting, humbling, and worth it.",
+      postData = {
+        title: 'What a Week!',
+        author: 'Gerardo Mena',
+        date: 'August 25, 2025',
+        publishedTime: '2025-08-25T00:00:00.000Z',
+        updatedTime: '2025-08-25T00:00:00.000Z',
+        excerpt:
+          'We rushed a documentary onto a Vegas jumbotron, then briefed the Harding Project on AI—exhausting, humbling, and worth it.',
         heroImage: '/blog-photo.png',
-        tags: ["Updates", "Documentary", "AI", "Conference"],
-        readTime: "3 min read",
+        tags: ['Updates', 'Documentary', 'AI', 'Conference'],
+        readTime: '3 min read',
         content: `Wow. What a productive week!
 
 We kicked things off with our first commissioned documentary style piece for a nonprofit that needed it—fast—for a horse show in Las Vegas. It was headed to the jumbotron, which meant every pixel had to be perfect. We tightened the cut and survived brutal high end render times.
@@ -33,17 +67,18 @@ I left grateful to be a part of all of it.
 
 Exhausting? Yes. Worth it? Absolutely. On to the next project. Our queue is already full again.`
       }
-      setPost(postData)
-      setLoading(false)
     } else if (slug === 'the-future-of-generative-engine-optimization') {
-      const postData = {
-        title: "The Future of Generative Engine Optimization",
-        author: "Gerardo Mena",
-        date: "2025-08-16",
-        excerpt: "The digital marketing landscape is in the midst of a seismic shift. Traditional SEO is making way for Generative Engine Optimization (GEO). As AI becomes integrated into search, understanding GEO is no longer futuristic—it's an immediate necessity.",
+      postData = {
+        title: 'The Future of Generative Engine Optimization',
+        author: 'Gerardo Mena',
+        date: 'August 16, 2025',
+        publishedTime: '2025-08-16T00:00:00.000Z',
+        updatedTime: '2025-08-16T00:00:00.000Z',
+        excerpt:
+          "The digital marketing landscape is in the midst of a seismic shift. Traditional SEO is making way for Generative Engine Optimization (GEO). As AI becomes integrated into search, understanding GEO is no longer futuristic—it's an immediate necessity.",
         heroImage: '/blog-1.webp',
-        tags: ["AI", "SEO", "GEO", "Search", "Strategy"],
-        readTime: "8 min read",
+        tags: ['AI', 'SEO', 'GEO', 'Search', 'Strategy'],
+        readTime: '8 min read',
         content: `# The Future of Search: A Deep Dive into Generative Engine Optimization (GEO)
 
 The digital marketing landscape is in the midst of a seismic shift. Traditional search engine optimization (SEO), long the cornerstone of online visibility, is making way for a new paradigm: Generative Engine Optimization (GEO). As artificial intelligence (AI) and large language models (LLMs) become increasingly integrated into our online experiences, understanding and implementing GEO is no longer a futuristic concept—it's an immediate necessity for any brand that wants to remain relevant.
@@ -127,67 +162,54 @@ Generative Engine Optimization is not a far-off concept; it's the present and fu
 - [Generative Engine Optimization (GEO): The Future of Search? | WordStream](https://www.wordstream.com/blog/generative-engine-optimization)
 - [What Is Generative Engine Optimization (GEO)? | Search Engine Land](https://searchengineland.com/what-is-generative-engine-optimization-geo-444418)
 - [Generative Engine Optimization: How to Optimize for AI Overviews | Semrush](https://www.semrush.com/blog/generative-engine-optimization/)`
-      };
-
-      
-      setPost(postData)
-      
-      // Set document title and meta description for SEO
-      document.title = `${postData.title} | Gerardo Mena - AI Strategy & Innovation`
-      
-      // Update meta description
-      let metaDescription = document.querySelector('meta[name="description"]')
-      if (!metaDescription) {
-        metaDescription = document.createElement('meta')
-        metaDescription.name = 'description'
-        document.head.appendChild(metaDescription)
       }
-      metaDescription.content = postData.excerpt
-      
-      // Add structured data for SEO
+    }
+
+    if (postData) {
+      setPost(postData)
+      setLoading(false)
+
+      const baseUrl = 'https://www.gerardo-mena.com'
       const structuredData = {
-        "@context": "https://schema.org",
-        "@type": "Article",
-        "headline": postData.title,
-        "description": postData.excerpt,
-        "image": `https://www.gerardo-mena.com${postData.heroImage}`,
-        "author": {
-          "@type": "Person",
-          "name": postData.author,
-          "url": "https://www.gerardo-mena.com/about"
+        '@context': 'https://schema.org',
+        '@type': 'Article',
+        headline: postData.title,
+        description: postData.excerpt,
+        image: `${baseUrl}${postData.heroImage}`,
+        author: {
+          '@type': 'Person',
+          name: postData.author,
+          url: `${baseUrl}/about`
         },
-        "publisher": {
-          "@type": "Organization",
-          "name": "Gerardo Mena",
-          "logo": {
-            "@type": "ImageObject",
-            "url": "https://www.gerardo-mena.com/GM-Logo.png"
+        publisher: {
+          '@type': 'Organization',
+          name: 'Gerardo Mena',
+          logo: {
+            '@type': 'ImageObject',
+            url: `${baseUrl}/GM-Logo.png`
           }
         },
-        "datePublished": postData.date,
-        "dateModified": postData.date,
-        "mainEntityOfPage": {
-          "@type": "WebPage",
-          "@id": `https://www.gerardo-mena.com/blog/${slug}`
+        datePublished: postData.publishedTime,
+        dateModified: postData.updatedTime || postData.publishedTime,
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': `${baseUrl}/blog/${slug}`
         },
-        "keywords": postData.tags.join(', '),
-        "articleSection": "AI Strategy",
-        "wordCount": postData.content.split(' ').length
+        keywords: postData.tags.join(', '),
+        articleSection: 'AI Strategy',
+        wordCount: postData.content.split(' ').length
       }
-      
-      // Add structured data script
-      let structuredDataScript = document.querySelector('script[type="application/ld+json"]')
-      if (!structuredDataScript) {
-        structuredDataScript = document.createElement('script')
-        structuredDataScript.type = 'application/ld+json'
-        document.head.appendChild(structuredDataScript)
-      }
+
+      const structuredDataScript = document.createElement('script')
+      structuredDataScript.type = 'application/ld+json'
+      structuredDataScript.id = 'structured-data-article'
       structuredDataScript.textContent = JSON.stringify(structuredData)
-      
-      setLoading(false)
+      document.head.appendChild(structuredDataScript)
     } else {
       setLoading(false)
     }
+
+    return removeStructuredData
   }, [slug])
 
   if (loading) {

--- a/src/pages/Contact.jsx
+++ b/src/pages/Contact.jsx
@@ -1,6 +1,16 @@
 import { useState } from 'react'
 
+import usePageMetadata from '../hooks/usePageMetadata'
+
 function Contact() {
+  usePageMetadata({
+    title: 'Contact Gerardo Mena | Start Your AI-Driven Project',
+    description:
+      'Connect with Gerardo Mena to build AI-powered marketing, storytelling, and digital experiences tailored to your mission.',
+    image: '/social-media.png',
+    url: 'https://www.gerardo-mena.com/contact'
+  })
+
   const [formData, setFormData] = useState({
     name: '',
     email: '',

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,4 +1,15 @@
+import usePageMetadata from '../hooks/usePageMetadata'
+
 function Home() {
+  usePageMetadata({
+    title: 'Gerardo Mena | AI Strategist, Creative Technologist & Storyteller',
+    description:
+      "Explore Gerardo Mena's award-winning blend of AI strategy, storytelling, and digital production that has generated millions of views and funding for clients.",
+    image: '/Gerardo-Mena-Future.webp',
+    url: 'https://www.gerardo-mena.com/',
+    type: 'website'
+  })
+
   return (
     <>
       {/* Hero Section */}

--- a/src/pages/Portfolio.jsx
+++ b/src/pages/Portfolio.jsx
@@ -1,4 +1,14 @@
+import usePageMetadata from '../hooks/usePageMetadata'
+
 function Portfolio() {
+  usePageMetadata({
+    title: "Portfolio | Gerardo Mena's AI Marketing, Writing & Design Work",
+    description:
+      'Review military-honed leadership, award-winning publications, and high-impact AI marketing campaigns that have generated millions of views and visitors.',
+    image: '/GEO-Feature.png',
+    url: 'https://www.gerardo-mena.com/portfolio'
+  })
+
   const literaryWorks = [
     {
       title: "A Much-Needed Treat, and a Welcome Surprise",

--- a/src/pages/Resume.jsx
+++ b/src/pages/Resume.jsx
@@ -1,4 +1,14 @@
+import usePageMetadata from '../hooks/usePageMetadata'
+
 function Resume() {
+  usePageMetadata({
+    title: 'Resume | Gerardo Mena – Web Developer & AI Strategist',
+    description:
+      'Download the comprehensive resume for Gerardo Mena, highlighting 10+ years in web development, Section 508 leadership, AI content creation, and digital strategy.',
+    image: '/social-media.png',
+    url: 'https://www.gerardo-mena.com/resume'
+  })
+
   return (
     <section className="py-20 px-8 pt-32">
       <div className="container mx-auto max-w-5xl">


### PR DESCRIPTION
## Summary
- add a reusable metadata hook to manage Open Graph, Twitter, and canonical tags
- apply tailored page titles, descriptions, and social images across the marketing and blog routes
- refresh blog post loading logic to publish structured data and use article feature images for sharing

## Testing
- pnpm build

------
https://chatgpt.com/codex/tasks/task_e_68e43fcab958832e9dbf2ea48186620d